### PR TITLE
Joint books dnn

### DIFF
--- a/gpu/app/books.py
+++ b/gpu/app/books.py
@@ -25,7 +25,6 @@ if not os.path.exists(libgen_dir): os.mkdir(libgen_dir)
 paths = Box(
     df=f"{libgen_file}.df",
     vecs=f"{libgen_file}.npy",
-    dnn=f"{libgen_file}.tf"
 )
 
 class Books(object):

--- a/gpu/app/books_dnn.py
+++ b/gpu/app/books_dnn.py
@@ -9,10 +9,13 @@ from tensorflow.keras.layers import Input, Dense
 from tensorflow.keras.models import Model, load_model
 from tensorflow.keras.callbacks import EarlyStopping
 from tensorflow.keras.optimizers import Adam
+from tensorflow.keras.utils import Sequence
 
-import pdb, logging
+import pdb, logging, math
+from tqdm import tqdm
+from os.path import exists
 from box import Box
-from common.utils import vars, is_test
+from common.utils import vars, THREADS
 from ml_tools import Similars
 from sklearn.preprocessing import minmax_scale
 import numpy as np
@@ -28,6 +31,9 @@ books = np.load(f"{libgen_file}.npy", mmap_mode='r')
 n_books, dims = books.shape[0], books.shape[1]
 split = int(n_books * .7)
 
+# TODO move to Sequence subclass
+# https://stackoverflow.com/questions/55889923/how-to-handle-the-last-batch-using-keras-fit-generator
+
 class BooksDNN(object):
     def __init__(self, vecs_user, df):
         self.user = vecs_user
@@ -42,19 +48,18 @@ class BooksDNN(object):
             user_val=self.df.user_rated
         )
 
-    def shuffle_idx(self, arr):
+    def rand_idx(self, arr):
         shuffle = np.arange(arr.shape[0])
         np.random.shuffle(shuffle)
         return shuffle
 
     def generator_cosine(self, batch, validation=False):
         mask = self.mask.book_val if validation else self.mask.book_train
-        bb = books[mask]
-        bb = bb[self.shuffle_idx(bb)]
-        while bb.size:
-            bb = bb[:batch]
-            a = bb
-            shuffle = self.shuffle_idx(a)
+        books_ = books[mask]
+        while True:
+            idx = self.rand_idx(books_)[:batch]
+            a = books_[idx]
+            shuffle = self.rand_idx(a)
             b = a[shuffle]
             x = np.hstack([a, b])
 
@@ -68,36 +73,34 @@ class BooksDNN(object):
     def generator_adjustments(self, batch, validation=False):
         mask = self.mask.user_val if validation else self.mask.user_train
         df = self.df[mask]
-        user = self.user
-        for i in range(user.shape[0]):
-            bb = books[mask]
-            df_ = df
-            while bb.size:
-                bb = bb[:batch]
-                a = np.repeat([user[i]], bb.shape[0], axis=0)
-                b = bb
-                x = np.hstack([a, b])
+        books_ = books[mask]
 
-                y = Similars(a, b).normalize().cosine(abs=True).value().diagonal()
-                # Push highly-rated books up, low-rated books down. Do that even stronger for user's own ratings.
-                # Using negative-score because cosine DISTANCE (less is better)
-                df_ = df_.iloc[:batch]
-                y = y - (y.std() * df_.global_score / 2.) \
-                    - (y.std() * df_.user_score * 2.)
-                yield x, y.values
+        while True:
+            entry = self.user[np.random.randint(0, self.user.shape[0])]
+            idx = self.rand_idx(books_)[:batch]
+            b = books_[idx]
+            df_ = df.iloc[idx]
+            a = np.repeat([entry], b.shape[0], axis=0)
+            x = np.hstack([a, b])
 
-    def generator_predict(self, batch, i):
-        bb = books
-        while bb.size:
-            bb = bb[:batch]
-            a = np.repeat([self.user[i]], bb.shape[0], axis=0)
+            y = Similars(a, b).normalize().cosine(abs=True).value().diagonal()
+            # Push highly-rated books up, low-rated books down. Do that even stronger for user's own ratings.
+            # Using negative-score because cosine DISTANCE (less is better)
+            y = y - (y.std() * df_.global_score / 2.) \
+                - (y.std() * df_.user_score * 2.)
+            yield x, y.values
+
+    def generator_predict(self, batch, x):
+        for i in range(0, books.shape[0], batch):
+            bb = books[i:i+batch]
+            a = np.repeat(x, bb.shape[0], axis=0)
             b = bb
             yield np.hstack([a, b])
 
     def init_model(self):
         input = Input(shape=(dims * 2,))
-        m = Dense(600, activation='tanh')(input)
-        m = Dense(100, activation='tanh')(m)
+        m = Dense(800, activation='relu')(input)
+        m = Dense(100, activation='relu')(m)
         m = Dense(1, activation='linear')(m)
         m = Model(input, m)
         # http://zerospectrum.com/2019/06/02/mae-vs-mse-vs-rmse/
@@ -105,25 +108,32 @@ class BooksDNN(object):
         m.compile(
             # loss='mae',
             loss='mse',
-            optimizer=Adam(learning_rate=.0003),
+            optimizer=Adam(learning_rate=.0001),
         )
         m.summary()
         self.m = m
 
     def learn_cosine_function(self):
         logger.info("DNN: learn cosine function")
+        if exists(fname):
+            logger.info("DNN: loading cosine-pretrained")
+            self.m = load_model(fname)
+            return
+
         # https://www.machinecurve.com/index.php/2020/04/06/using-simple-generators-to-flow-data-from-file-with-keras/
         # https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit
         batch = 128
         self.m.fit(
             self.generator_cosine(batch),
-            # epochs=1,
-            epochs=40,
+            epochs=10,
             callbacks=[self.es],
             validation_data=self.generator_cosine(batch, validation=True),
-            steps_per_epoch=int(self.mask.book_train.sum()/batch),
-            validation_steps=int(self.mask.book_val.sum()/batch),
+            steps_per_epoch=math.ceil(self.mask.book_train.sum()/batch),
+            validation_steps=math.ceil(self.mask.book_val.sum()/batch),
+            # workers=THREADS,
+            # use_multiprocessing=True
         )
+        self.m.save(fname)
 
     def learn_adjustments(self):
         if self.df.any_rated.sum() < 3: return
@@ -132,11 +142,12 @@ class BooksDNN(object):
         self.m.fit(
             self.generator_adjustments(batch),
             epochs=20,  # too many epochs overfits (eg to CBT). Maybe adjust LR *down*, or other?
-            # epochs=1,
-            callbacks=[self.es],
+            # callbacks=[self.es],
             validation_data=self.generator_adjustments(batch, validation=True),
-            steps_per_epoch=int(self.mask.user_train.sum()*self.user.shape[0]/batch),
-            validation_steps=int(self.mask.user_val.sum()*self.user.shape[0]/batch)
+            steps_per_epoch=math.ceil(self.mask.user_train.sum()/batch),
+            validation_steps=math.ceil(self.mask.user_val.sum()/batch),
+            # workers=THREADS,
+            # use_multiprocessing=True
         )
 
     def train(self):
@@ -145,17 +156,28 @@ class BooksDNN(object):
         self.learn_adjustments()
 
     def predict(self):
-        batch = 10000
+        user = self.user
+        batch = 1000
+        if user.shape[0] < 5:
+            clusters = user
+        else:
+            labels = Similars(user).normalize().cluster(algo='agglomorative').value()
+            clusters = np.vstack([
+                user[labels == l].mean(axis=0).squeeze()
+                for l in range(labels.max())
+            ])
+            print("n_clusters", clusters.shape[0])
         best = None
-        for i in [0]:  # range(self.user.shape[0]):
+        for x in clusters:
             preds = self.m.predict(
-                self.generator_predict(batch, i),
-                steps=int(n_books/batch),
-                verbose=1
+                self.generator_predict(batch, [x]),
+                steps=math.ceil(n_books/batch),
+                verbose=1,
+                # workers=THREADS,
+                # use_multiprocessing=True
             ).squeeze()
             if best is None:
                 best = preds
                 continue
             best = np.vstack([best, preds]).min(axis=0)
-        # error Length of values (290000) does not match length of index (297557)
         return best

--- a/gpu/app/books_dnn.py
+++ b/gpu/app/books_dnn.py
@@ -1,0 +1,117 @@
+# https://github.com/tensorflow/tensorflow/issues/2117
+import tensorflow as tf
+config = tf.compat.v1.ConfigProto()
+config.gpu_options.allow_growth = True
+session = tf.compat.v1.Session(config=config)
+
+from tensorflow.keras import backend as K
+from tensorflow.keras.layers import Input, Dense
+from tensorflow.keras.models import Model, load_model
+from tensorflow.keras.callbacks import EarlyStopping
+from tensorflow.keras.optimizers import Adam
+
+import pdb, logging
+from common.utils import vars
+from ml_tools import Similars
+from sklearn.preprocessing import minmax_scale
+import numpy as np
+logger = logging.getLogger(__name__)
+
+# TODO refactor with books.py
+ALL_BOOKS = True
+libgen_dir = "/storage/libgen"
+libgen_file = f"{libgen_dir}/{vars.ENVIRONMENT}_{'all' if ALL_BOOKS else 'psych'}"  # '.ext
+fname = f"{libgen_file}.tf"
+
+books = np.load(f"{libgen_file}.npy", mmap_mode='r')
+n_books, dims = books.shape[0], books.shape[1]
+split_ = int(n_books * .7)
+batch = 250
+
+class BooksDNN(object):
+    def __init__(self, vecs_user, df):
+        self.user = vecs_user
+        self.df = df
+        self.m = None
+
+    def generator(self, user_i=None, fine_tune=False, validation=False):
+        user = self.vecs_user
+        user_range = range(user.shape[0]) if user_i is None else [user_i]
+
+        mask = np.arange(n_books)
+        mask = self.df.any_rated if fine_tune else mask
+        mask = mask[:split_] if validation else mask[split_:]
+        books_ = books[mask,:]
+        df_ = self.df.iloc[mask]
+        for i in user_range:
+            for j in range(0, books_.shape[0], batch):
+                book_batch = books_[j:j+batch]
+                user_batch = np.repeat(user[i:i+1], book_batch.shape[0], axis=0)
+                x = np.hstack([user_batch, book_batch])
+
+                y = Similars(user_batch, book_batch).normalize().cosine(abs=True).value()
+                y = y.min(axis=0)
+
+                df_batch = df_.iloc[j:j+batch]
+                # Push highly-rated books up, low-rated books down. Do that even stronger for user's own ratings.
+                # Using negative-score because cosine DISTANCE (less is better)
+                y = y - (y.std() * df_batch.global_score / 2.) \
+                    - (y.std() * df_batch.user_score * 2.)
+                y = minmax_scale(y)
+
+                yield x, y
+
+    def init_model(self):
+        input = Input(shape=(dims * 2,))
+        m = Dense(600, activation='relu')(input)
+        m = Dense(100, activation='relu')(m)
+        m = Dense(1, activation='sigmoid')(m)
+        m = Model(input, m)
+        # http://zerospectrum.com/2019/06/02/mae-vs-mse-vs-rmse/
+        # MAE because we _want_ outliers (user score adjustments)
+        m.compile(
+            loss='mae',
+            optimizer=Adam(learning_rate=.0003),
+        )
+        m.summary()
+        self.m = m
+        # self.es = EarlyStopping(monitor='val_loss', mode='min', patience=3, min_delta=.0001)
+        self.es = EarlyStopping(monitor='val_loss', mode='min', patience=3, min_delta=.0001)
+
+    def learn_cosine_function(self):
+        logger.info("DNN: learn cosine function")
+        # https://www.machinecurve.com/index.php/2020/04/06/using-simple-generators-to-flow-data-from-file-with-keras/
+        self.m.fit(
+            self.generator(),
+            epochs=40,
+            batch_size=128,
+            shuffle=True,
+            callbacks=[self.es],
+            validation_data=self.generator(validation=True),
+            # steps_per_epoch=books[:split_].shape[0] * self.user.shape[0],
+            # do i need this? (since validation_data is finite)
+            # validation_steps=int(books[:split_].shape[0]/batch),
+        )
+
+    def learn_adjustments(self):
+        logger.info("DNN: learn adjustments function")
+        self.model.fit(
+            self.generator(fine_tune=True),
+            epochs=20,  # too many epochs overfits (eg to CBT). Maybe adjust LR *down*, or other?
+            batch_size=16,
+            callbacks=[self.es],
+            shuffle=True,
+            validation_data=self.generator(fine_tune=True, validation=True),
+            # validation_steps=int(books[split_:].shape[0]/batch)
+        )
+
+    def train(self):
+        self.init_model()
+        self.learn_cosine_function()
+        self.learn_adjustments()
+
+    def predict(self):
+        return np.hstack([
+            self.m.predict(self.generator(user_i=i))
+            for i in self.user.shape[0]
+        ]).min(axis=1)


### PR DESCRIPTION
Skip the autoencoder Frankenstein, much cleaner approach: use `np.load(mmap_mode)` with `keras.fit(generator)` so I don't overwhelm RAM, while able to join-train a model that learns cosine sims with adjustmens. May use autoencoder in the future for dim-reducing user/entry vectors for DB storage, but skipping for now.