### PR TITLE
Refresh token

### DIFF
--- a/client/src/Auth.js
+++ b/client/src/Auth.js
@@ -48,9 +48,9 @@ function Auth() {
     const formData = new FormData()
     formData.append('username', username)
     formData.append('password', password)
-    const res = await submit_('auth/jwt/login', 'POST', formData)
+    const res = await submit_('auth/login', 'POST', formData)
     if (res === false) {return}
-    dispatch(onAuth(res.access_token))
+    dispatch(onAuth(res))
   }
 
   const submitLogin = async e => {

--- a/client/src/Auth.js
+++ b/client/src/Auth.js
@@ -11,7 +11,7 @@ import Error from './Error'
 import {spinner} from './utils'
 
 import { useSelector, useDispatch } from 'react-redux'
-import { fetch_, onAuth } from './redux/actions';
+import { fetch_, setJwt } from './redux/actions';
 
 function Auth() {
   const [submitting, setSubmitting] = useState(false)
@@ -50,7 +50,7 @@ function Auth() {
     formData.append('password', password)
     const res = await submit_('auth/login', 'POST', formData)
     if (res === false) {return}
-    dispatch(onAuth(res))
+    dispatch(setJwt(res))
   }
 
   const submitLogin = async e => {

--- a/client/src/redux/reducer.js
+++ b/client/src/redux/reducer.js
@@ -16,7 +16,7 @@ import {
 const emptyRes = {code: null, message: null, data: null}
 
 const initialState = {
-  jwt: localStorage.getItem('jwt'),
+  jwt: localStorage.getItem('access_token'),
   user: null,
   as: null,
   asUser: null,

--- a/common/models.py
+++ b/common/models.py
@@ -106,9 +106,7 @@ class User(Base, SQLAlchemyBaseUserTable):
                 .filter_by(user_id=as_id, email=viewer.email) \
                 .first()
         else:
-            # as_user = viewer
-            # fastapi-users giving me beef, re-load from sqlalchemy
-            as_user = db.session.query(User).get(viewer.id)
+            as_user = viewer
         return as_user, snooping
 
     @property

--- a/server.dockerfile
+++ b/server.dockerfile
@@ -26,7 +26,8 @@ RUN pip install \
   pytest-timeout \
   lorem-text \
   boto3 \
-  dynaconf
+  dynaconf \
+  fastapi-jwt-auth
 
 COPY ./server/app /app/app
 COPY ./common /app/common

--- a/server/app/app_jwt.py
+++ b/server/app/app_jwt.py
@@ -12,15 +12,10 @@ import common.models as M
 from app.google_analytics import ga
 
 
-jwt_lifetime = 60 * 60 * 24 * 7  # 1wk. TODO implement token refresh
-jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=jwt_lifetime)
+jwt_authentication = JWTAuthentication(secret=SECRET, lifetime_seconds=60*5)
 fastapi_users = FastAPIUsers(
     M.user_db, [jwt_authentication], M.FU_User, M.FU_UserCreate, M.FU_UserUpdate, M.FU_UserDB,
 )
-
-@app.post("/auth/jwt/refresh")
-async def refresh_jwt(response: Response, user=Depends(fastapi_users.get_current_user)):
-    return await jwt_authentication.get_login_response(user, response)
 
 def on_after_register(user: M.FU_UserDB, request: Request):
     ga(user.id, 'user', 'register')
@@ -33,15 +28,17 @@ def on_after_register(user: M.FU_UserDB, request: Request):
 def on_after_forgot_password(user: M.FU_UserDB, token: str, request: Request):
     send_mail(user.email, "forgot-password", token)
 
-def on_after_update(user: M.FU_UserDB, updated_user_data: Dict[str, Any], request: Request):
-    print(f"User {user.id} has been updated with the following data: {updated_user_data}")
+# def on_after_update(user: M.FU_UserDB, updated_user_data: Dict[str, Any], request: Request):
+#     print(f"User {user.id} has been updated with the following data: {updated_user_data}")
 
-app.include_router(
-    fastapi_users.get_auth_router(jwt_authentication), prefix="/auth/jwt", tags=["auth"]
-)
+# app.include_router(
+#     fastapi_users.get_auth_router(jwt_authentication), prefix="/auth/jwt", tags=["auth"]
+# )
+
 app.include_router(
     fastapi_users.get_register_router(on_after_register), prefix="/auth", tags=["auth"]
 )
+
 app.include_router(
     fastapi_users.get_reset_password_router(
         SECRET, after_forgot_password=on_after_forgot_password
@@ -49,4 +46,104 @@ app.include_router(
     prefix="/auth",
     tags=["auth"],
 )
-app.include_router(fastapi_users.get_users_router(on_after_update), prefix="/users", tags=["users"])
+
+# app.include_router(fastapi_users.get_users_router(on_after_update), prefix="/users", tags=["users"])
+
+
+
+
+from fastapi import FastAPI, HTTPException, Depends, Request, APIRouter
+from fastapi_jwt_auth import AuthJWT
+from pydantic import BaseModel
+from common.utils import SECRET
+from fastapi_sqlalchemy import db
+from fastapi import APIRouter, Depends, HTTPException, Response, status
+from fastapi.security import OAuth2PasswordRequestForm
+
+from fastapi_users.router.common import ErrorCode
+
+
+# in production you can use Settings management
+# from pydantic to get secret key from .env
+class Settings(BaseModel):
+    authjwt_secret_key: str = SECRET
+    # authjwt_access_token_expires: int = 10
+
+
+# callback to get your configuration
+@AuthJWT.load_config
+def get_config():
+    return Settings()
+
+
+router = APIRouter()
+
+
+# Standard login endpoint. Will return a fresh access token and a refresh token
+@router.post('/login')
+async def login(
+    credentials: OAuth2PasswordRequestForm = Depends(),
+    Authorize: AuthJWT = Depends()
+):
+    user = await M.user_db.authenticate(credentials)
+
+    if user is None or not user.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=ErrorCode.LOGIN_BAD_CREDENTIALS,
+        )
+        # raise HTTPException(status_code=401, detail="Bad username or password")
+
+    """
+    create_access_token supports an optional 'fresh' argument,
+    which marks the token as fresh or non-fresh accordingly.
+    As we just verified their username and password, we are
+    going to mark the token as fresh here.
+    """
+    access_token = Authorize.create_access_token(subject=str(user.id), fresh=True)
+    refresh_token = Authorize.create_refresh_token(subject=str(user.id))
+    return {"access_token": access_token, "refresh_token": refresh_token}
+
+
+@router.post('/refresh')
+def refresh(Authorize: AuthJWT = Depends()):
+    """
+    Refresh token endpoint. This will generate a new access token from
+    the refresh token, but will mark that access token as non-fresh,
+    as we do not actually verify a password in this endpoint.
+    """
+    Authorize.jwt_refresh_token_required()
+
+    current_user = Authorize.get_jwt_subject()
+    new_access_token = Authorize.create_access_token(subject=current_user, fresh=True)
+    return {"access_token": new_access_token}
+
+# @router.post('/fresh-login')
+# def fresh_login(user: M.FU_UserCreate, Authorize: AuthJWT = Depends()):
+#     """
+#     Fresh login endpoint. This is designed to be used if we need to
+#     make a fresh token for a user (by verifying they have the
+#     correct username and password). Unlike the standard login endpoint,
+#     this will only return a new access token, so that we don't keep
+#     generating new refresh tokens, which entirely defeats their point.
+#     """
+#     passw = users.get(user.username, None)
+#     if not (passw and passw == user.password):
+#         raise HTTPException(status_code=401, detail="Bad username or password")
+#
+#     new_access_token = Authorize.create_access_token(subject=user.username,fresh=True)
+#     return {"access_token": new_access_token}
+
+from fastapi_jwt_auth.exceptions import AuthJWTException
+
+def jwt_user(Authorize: AuthJWT = Depends()):
+    try:
+        Authorize.fresh_jwt_required()
+    except AuthJWTException as exc:
+        # raise HTTPException(status_code=exc.status_code, detail=exc.message)
+        raise HTTPException(status_code=400, detail="JWT error")
+    uid = Authorize.get_jwt_subject()
+    return db.session.query(M.User).get(uid)
+
+
+app.include_router(router, prefix='/auth')

--- a/server/app/habitica.py
+++ b/server/app/habitica.py
@@ -26,9 +26,12 @@ def sync_for(user):
         headers=headers
     ).json()['data']
     huser = requests.get(
-        'https://habitica.com/api/v3/user?userFields=lastCron,needsCron',
+        'https://habitica.com/api/v3/user?userFields=lastCron,needsCron,preferences',
         headers=headers
     ).json()['data']
+
+    # don't pull field if they're in the inn
+    if huser['preferences']['sleep']: return
 
     # Use SQL to determine day, so not managing timezones in python + sql
     tz = M.User.tz(db.session, user.id)


### PR DESCRIPTION
Uses fastapi-jwt-auth to enable refresh tokens on jwt-protected routes for better security. Keeps fastapi-users for the app-level stuff like user-model setup, login/register, forgot-password, & forthcoming email verification. fastapi-users will be adding refresh tokens eventually, so may revert this in the future. Also, still not sure if I want to be handling auth on my end, and instead just let Cognito take care of it #107 - but this is a security stop-gap for now.